### PR TITLE
fix(dashboard): keep missed days silent

### DIFF
--- a/src/app/dashboard/DashboardClient.tsx
+++ b/src/app/dashboard/DashboardClient.tsx
@@ -17,7 +17,6 @@ import type { JournalEntry } from '@/lib/dataService';
 import { getSessionCount, incrementSessionCountOncePerAppOpen } from '@/lib/onboarding';
 import { getReflectionUsageSummary } from '@/lib/subscription';
 import { getSettings } from '@/lib/settings';
-import { cancelReminder, scheduleReturnReminder } from '@/lib/notifications';
 import { getActivePathway, getPathwayById } from '@/lib/pathways';
 import {
   dismissContinuityCardForSession,
@@ -81,12 +80,6 @@ export default function DashboardClient() {
     const active = getActivePathway();
     setActivePathwayId(active?.pathwayId || '');
     setActiveStep(active?.currentStep || 0);
-
-    if ((context.daysSinceLastEntry || 0) >= 2) {
-      scheduleReturnReminder().catch(() => {});
-    } else {
-      cancelReminder('return').catch(() => {});
-    }
   }, []);
 
   useEffect(() => {
@@ -150,7 +143,7 @@ export default function DashboardClient() {
     >
       <div style={{ display: 'grid', gap: DESIGN.spacing.md }}>
         <SanctuaryText variant="caption">
-          {sessionCount === 2 ? 'Welcome back.' : greeting}
+          {sessionCount === 2 ? 'You are here.' : greeting}
         </SanctuaryText>
 
         {continuityCard ? (

--- a/src/services/containers/localContainersService.ts
+++ b/src/services/containers/localContainersService.ts
@@ -126,7 +126,7 @@ export const CORE_CONTAINERS: Container[] = [
       { day: 4, title: 'The Face', prompt: "Think of someone you saw today. What did their face reveal beyond words?", kheperaGuidance: 'Reflect on social cues and empathy.', reflectionFocus: 'observation' },
       { day: 5, title: 'The Pattern', prompt: 'What did you do today on autopilot? How did it actually feel?', kheperaGuidance: 'Notice routine without judgment.', reflectionFocus: 'habit awareness' },
       { day: 6, title: 'The Absence', prompt: 'What was missing from today? Not wrong, simply absent.', kheperaGuidance: 'Hold absence with curiosity.', reflectionFocus: 'absence' },
-      { day: 7, title: 'The Shift', prompt: 'After a week of noticing, what do you see now that you missed before?', kheperaGuidance: 'Integrate the full week.', reflectionFocus: 'integration' },
+      { day: 7, title: 'The Shift', prompt: 'After a week of noticing, what feels clearer from here?', kheperaGuidance: 'Integrate the full week.', reflectionFocus: 'integration' },
     ], 'noticing'),
   },
 ];


### PR DESCRIPTION
Removes absence-triggered return reminder scheduling and softens return language.

Includes:
- removes local reminder scheduling based on daysSinceLastEntry
- replaces generic re-engagement greeting with neutral presence language
- removes remaining missed-language prompt copy

Validation:
- TypeScript passed
- production build passed
- scoped diff check passed

No Khepera, memory, crisis, submission, persistence, or orchestration changes.