### PR TITLE
fix(insights): soften emotional legibility surface

### DIFF
--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -53,15 +53,15 @@ export default function InsightsPage() {
 
   if (!isInitialized || loading) {
     return (
-      <SanctuaryLayout header={<SanctuaryHeader title="Insights" showBack />}>
-        <LoadingState message="Gathering your patterns..." variant="page" />
+      <SanctuaryLayout header={<SanctuaryHeader title="Reflections" showBack />}>
+        <LoadingState message="Letting the reflections gather..." variant="page" />
       </SanctuaryLayout>
     );
   }
 
   if (error) {
     return (
-      <SanctuaryLayout header={<SanctuaryHeader title="Insights" showBack />}>
+      <SanctuaryLayout header={<SanctuaryHeader title="Reflections" showBack />}>
         <ErrorState variant="inline" message={error} />
       </SanctuaryLayout>
     );
@@ -69,21 +69,21 @@ export default function InsightsPage() {
 
   if (!entries.length) {
     return (
-      <SanctuaryLayout header={<SanctuaryHeader title="Insights" showBack />}>
-        <EmptyState title="No insights yet" message="After a few entries, patterns will emerge here." />
+      <SanctuaryLayout header={<SanctuaryHeader title="Reflections" showBack />}>
+        <EmptyState title="Nothing has gathered yet" message="After a few entries, themes may begin to appear here." />
       </SanctuaryLayout>
     );
   }
 
   return (
-    <SanctuaryLayout header={<SanctuaryHeader title="Insights" showBack />}>
+    <SanctuaryLayout header={<SanctuaryHeader title="Reflections" showBack />}>
       <div style={{ display: 'grid', gap: DESIGN.spacing.md }}>
         <SanctuaryCard>
           <SanctuaryText variant="khepera" style={{ marginBottom: DESIGN.spacing.xs }}>
-            Khepera notices
+            Khepera reflects
           </SanctuaryText>
           <SanctuaryText variant="body">
-            You have written {entries.length} reflections. Your words are building a clearer map of what you carry.
+            You have written {entries.length} reflections. Your words are building a gentler picture of what you carry.
           </SanctuaryText>
         </SanctuaryCard>
 
@@ -103,10 +103,10 @@ export default function InsightsPage() {
 
         <SanctuaryCard>
           <SanctuaryText variant="caption" style={{ marginBottom: DESIGN.spacing.sm }}>
-            Reflection cadence
+            Reflection rhythm
           </SanctuaryText>
           <SanctuaryText variant="body">
-            Last entry: {new Date(entries[0]?.createdAt || Date.now()).toLocaleDateString()}.
+            Most recent reflection: {new Date(entries[0]?.createdAt || Date.now()).toLocaleDateString()}.
           </SanctuaryText>
         </SanctuaryCard>
       </div>

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -41,14 +41,9 @@ export default function InsightsPage() {
     };
   }, [getJournalEntries]);
 
-  const moodCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    entries.forEach((entry) => {
-      entry.emotions?.forEach((emotion) => {
-        counts.set(emotion, (counts.get(emotion) || 0) + 1);
-      });
-    });
-    return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const recentlyNamedTones = useMemo(() => {
+    const tones = entries.flatMap((entry) => entry.emotions || []);
+    return Array.from(new Set(tones.filter(Boolean))).slice(0, 5);
   }, [entries]);
 
   if (!isInitialized || loading) {
@@ -89,13 +84,12 @@ export default function InsightsPage() {
 
         <SanctuaryCard>
           <SanctuaryText variant="caption" style={{ marginBottom: DESIGN.spacing.sm }}>
-            Most present moods
+            Recently named tones
           </SanctuaryText>
           <div style={{ display: 'grid', gap: DESIGN.spacing.xs }}>
-            {moodCounts.slice(0, 5).map(([emotion, count]) => (
+            {recentlyNamedTones.map((emotion) => (
               <div key={emotion} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <SanctuaryText variant="body">{emotion}</SanctuaryText>
-                <SanctuaryText variant="caption">{count}</SanctuaryText>
               </div>
             ))}
           </div>


### PR DESCRIPTION
Softens the Reflections surface so emotional legibility remains non-quantified and non-analytic.

Includes:
- reframes insights/pattern language into softer reflection language
- removes ranked mood frequency counts
- replaces mood ranking with recently named tones

Validation:
- TypeScript passed
- production build passed
- scoped diff check passed

No Khepera, memory, crisis, submission, persistence, or orchestration changes.