### PR TITLE
fix(returns): strengthen resurfacing restraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "design:validate": "node scripts/validate-design.js",
     "dev": "next dev",
     "e2e:navigation": "node scripts/e2e-navigation.mjs",
+    "qa:khepera-guards": "node scripts/check-resurfacing-guardrails.js",
+    "qa:return-restraint-guards": "node scripts/check-resurfacing-guardrails.js",
     "lint": "eslint",
     "prepare": "husky",
     "start": "next start",

--- a/scripts/check-resurfacing-guardrails.js
+++ b/scripts/check-resurfacing-guardrails.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(__dirname, '..', relativePath), 'utf8');
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function collectStringLiterals(source) {
+  const literals = [];
+  const stringLiteralPattern = /(['"`])((?:\\.|(?!\1)[\s\S])*)\1/g;
+  let match;
+
+  while ((match = stringLiteralPattern.exec(source)) !== null) {
+    literals.push(match[2]);
+  }
+
+  return literals;
+}
+
+const userFacingResurfacingFiles = [
+  'src/components/journal/JournalFlow.tsx',
+  'src/app/insights/page.tsx',
+  'src/services/mirror/mirrorService.ts',
+  'src/services/notifications/notificationCopy.ts',
+  'src/services/notifications/localReminderService.ts',
+];
+
+const forbiddenCopy = [
+  /remember this/i,
+  /on this day/i,
+  /look how far/i,
+  /\bprogress\b/i,
+  /dominant emotion/i,
+  /top emotion/i,
+  /\bfrequency\b/i,
+  /\bstreak\b/i,
+  /\bmissed\b/i,
+  /catch up/i,
+];
+
+for (const file of userFacingResurfacingFiles) {
+  const source = read(file);
+  const badLiteral = collectStringLiterals(source).find((literal) =>
+    forbiddenCopy.some((pattern) => pattern.test(literal))
+  );
+
+  assert(!badLiteral, `${file} contains unsafe resurfacing-facing copy: "${badLiteral}"`);
+}
+
+const selectReturnSource = read('src/services/returns/selectReturn.ts');
+const suppressReturnsSource = read('src/services/returns/suppressReturns.ts');
+const dataServiceSource = read('src/services/data/dataService.ts');
+
+assert(
+  !selectReturnSource.includes("return 'processing';\n}"),
+  'selectReturn must not collapse every emotional tone to processing'
+);
+assert(
+  selectReturnSource.includes('normalizeEmotionalTone(entry.emotionalTone)'),
+  'selectReturn must read persisted top-level emotionalTone metadata'
+);
+assert(
+  selectReturnSource.includes('normalizeEmotionalTone(entry.aiAnalysis?.emotionalTone)'),
+  'selectReturn must preserve legacy aiAnalysis emotionalTone compatibility'
+);
+assert(
+  selectReturnSource.includes('normalizeEmotionalTone(entry.emotions[0])'),
+  'selectReturn must preserve local queued/check-in tone compatibility'
+);
+assert(
+  suppressReturnsSource.includes('high_intensity_hold'),
+  'return suppression must keep high-intensity hold behavior'
+);
+assert(
+  suppressReturnsSource.includes('weak_current_metadata'),
+  'return suppression must prefer silence when current metadata is weak'
+);
+assert(
+  suppressReturnsSource.includes('recent_return_spacing'),
+  'return suppression must keep recent return spacing behavior'
+);
+assert(
+  dataServiceSource.includes('emotionalTone: typeof data.emotionalTone'),
+  'dataService must preserve persisted emotionalTone metadata for return selection'
+);
+assert(
+  dataServiceSource.includes('themes: this.toStringArray(data.themes)'),
+  'dataService must preserve persisted theme metadata for return selection'
+);
+
+console.log('Resurfacing restraint guardrails passed.');

--- a/src/services/data/dataService.ts
+++ b/src/services/data/dataService.ts
@@ -4,7 +4,7 @@ import { getFirestoreDb } from '@/services/firebase/firebaseService';
 import { STORAGE_KEYS } from '@/config/storageKeys';
 import { getStorageItemWithFallback, setStorageItemNormalized } from '@/utils/storage';
 import { getAllQueuedEntries } from '@/services/offline/localQueue';
-import type { QueuedEntry } from '@/types/journal';
+import type { EmotionalTone, QueuedEntry, ThemeTag } from '@/types/journal';
 
 export interface UserProfile {
   id: string;
@@ -44,9 +44,11 @@ export interface JournalEntry {
   kheperaReflection?: string;
   kheperaFrameworks?: string[];
   moodWords?: string[];
+  emotionalTone?: EmotionalTone;
+  themes?: ThemeTag[];
   insights?: string[];
   aiAnalysis?: {
-    emotionalTone: number;
+    emotionalTone: number | string;
     themes: string[];
     suggestions: string[];
     breakthroughDetected: boolean;
@@ -110,6 +112,10 @@ class DataService {
     return new Date();
   }
 
+  private toStringArray(value: unknown): string[] {
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  }
+
   private mapSessionToJournalEntry(id: string, data: Record<string, unknown>): JournalEntry {
     const content = typeof data.entryText === 'string'
       ? data.entryText
@@ -140,6 +146,18 @@ class DataService {
       kheperaReflection,
       insights: seed ? [seed] : [],
       moodWords: Array.isArray(data.moodWords) ? data.moodWords.filter((item): item is string => typeof item === 'string') : undefined,
+      emotionalTone: typeof data.emotionalTone === 'string' ? data.emotionalTone as EmotionalTone : undefined,
+      themes: this.toStringArray(data.themes) as ThemeTag[],
+      aiAnalysis: data.aiAnalysis && typeof data.aiAnalysis === 'object'
+        ? {
+          emotionalTone: typeof (data.aiAnalysis as { emotionalTone?: unknown }).emotionalTone === 'string' || typeof (data.aiAnalysis as { emotionalTone?: unknown }).emotionalTone === 'number'
+            ? (data.aiAnalysis as { emotionalTone: string | number }).emotionalTone
+            : 'processing',
+          themes: this.toStringArray((data.aiAnalysis as { themes?: unknown }).themes),
+          suggestions: this.toStringArray((data.aiAnalysis as { suggestions?: unknown }).suggestions),
+          breakthroughDetected: (data.aiAnalysis as { breakthroughDetected?: unknown }).breakthroughDetected === true,
+        }
+        : undefined,
     };
   }
 
@@ -158,6 +176,8 @@ class DataService {
       updatedAt: this.toDate(entry.syncedAt || entry.writtenAt),
       kheperaReflection: entry.kheperaResponse,
       insights: entry.seed ? [entry.seed] : [],
+      emotionalTone: entry.dominantTone,
+      themes: entry.recurringThemes as ThemeTag[],
     };
   }
 

--- a/src/services/returns/selectReturn.ts
+++ b/src/services/returns/selectReturn.ts
@@ -9,6 +9,17 @@ import type {
 import { rankCandidates } from './rankCandidates';
 import { suppressReturns } from './suppressReturns';
 
+const ALLOWED_TONES = new Set<EmotionalTone>([
+  'processing',
+  'grief',
+  'anger',
+  'anxiety',
+  'clarity',
+  'numbness',
+  'tenderness',
+  'ambivalence',
+]);
+
 function toTimestamp(value: JournalEntry['createdAt']): number {
   if (typeof (value as unknown as { toDate?: () => Date }).toDate === 'function') {
     return (value as unknown as { toDate: () => Date }).toDate().getTime();
@@ -27,18 +38,49 @@ function toCandidate(entry: JournalEntry): ReturnCandidateMetadata {
 }
 
 function toEmotionalTone(entry: JournalEntry): EmotionalTone {
-  if (entry.aiAnalysis?.emotionalTone !== undefined) {
-    return 'processing';
-  }
-
-  return 'processing';
+  return (
+    normalizeEmotionalTone(entry.emotionalTone)
+    ?? normalizeEmotionalTone(entry.aiAnalysis?.emotionalTone)
+    ?? normalizeEmotionalTone(entry.emotions[0])
+    ?? 'processing'
+  );
 }
 
 function toThemes(entry: JournalEntry): ThemeTag[] {
-  const themes = entry.aiAnalysis?.themes || entry.tags;
+  const themes = entry.themes?.length ? entry.themes : entry.aiAnalysis?.themes || entry.tags;
   return themes
     .map((theme) => normalizeTheme(theme))
     .filter((theme): theme is ThemeTag => Boolean(theme));
+}
+
+function normalizeEmotionalTone(value: unknown): EmotionalTone | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.toLowerCase().replace(/[\s-]+/g, '_');
+  const aliases: Record<string, EmotionalTone> = {
+    anxious: 'anxiety',
+    anxiety: 'anxiety',
+    angry: 'anger',
+    anger: 'anger',
+    grief: 'grief',
+    heavy: 'grief',
+    numb: 'numbness',
+    numbness: 'numbness',
+    tender: 'tenderness',
+    tenderness: 'tenderness',
+    okay: 'clarity',
+    clear: 'clarity',
+    clarity: 'clarity',
+    searching: 'ambivalence',
+    mixed: 'ambivalence',
+    ambivalence: 'ambivalence',
+    processing: 'processing',
+  };
+  const tone = aliases[normalized] ?? normalized;
+
+  return ALLOWED_TONES.has(tone as EmotionalTone) ? (tone as EmotionalTone) : null;
 }
 
 function normalizeTheme(theme: string): ThemeTag | null {

--- a/src/services/returns/suppressReturns.ts
+++ b/src/services/returns/suppressReturns.ts
@@ -1,24 +1,47 @@
 import type { ReturnCandidateMetadata, ReturnHistoryMetadata } from '@/types/return';
 
 const HIGH_INTENSITY_TONES = new Set(['grief', 'anger', 'anxiety']);
+const MIN_RETURN_SPACING_MS = 1000 * 60 * 60 * 24 * 5;
 
 interface SuppressReturnInput {
   currentEntry?: ReturnCandidateMetadata;
   recentReturns: ReturnHistoryMetadata[];
+  now?: number;
 }
 
 export interface ReturnSuppressionDecision {
   suppressed: boolean;
-  reason?: 'high_intensity_hold';
+  reason?: 'high_intensity_hold' | 'weak_current_metadata' | 'recent_return_spacing';
 }
 
 export function suppressReturns({
   currentEntry,
+  recentReturns,
+  now = Date.now(),
 }: SuppressReturnInput): ReturnSuppressionDecision {
+  if (!currentEntry || currentEntry.themes.length === 0 || currentEntry.emotionalTone === 'processing') {
+    return {
+      suppressed: true,
+      reason: 'weak_current_metadata',
+    };
+  }
+
   if (currentEntry && HIGH_INTENSITY_TONES.has(currentEntry.emotionalTone)) {
     return {
       suppressed: true,
       reason: 'high_intensity_hold',
+    };
+  }
+
+  const mostRecentReturn = recentReturns
+    .map((recentReturn) => recentReturn.surfacedAt)
+    .filter((surfacedAt) => Number.isFinite(surfacedAt))
+    .sort((left, right) => right - left)[0];
+
+  if (mostRecentReturn && now - mostRecentReturn < MIN_RETURN_SPACING_MS) {
+    return {
+      suppressed: true,
+      reason: 'recent_return_spacing',
     };
   }
 

--- a/src/types/return.ts
+++ b/src/types/return.ts
@@ -43,6 +43,10 @@ export interface ReturnSelectionResult {
   entryId: string | null;
   returnType: ReturnType;
   suppressed: boolean;
-  reason?: 'high_intensity_hold' | 'missing_entry_context';
+  reason?:
+    | 'high_intensity_hold'
+    | 'missing_entry_context'
+    | 'weak_current_metadata'
+    | 'recent_return_spacing';
   candidate?: RankedReturnCandidate;
 }


### PR DESCRIPTION
Strengthens return resurfacing restraint so ALCHM prefers silence over mistimed resurfacing.

Includes:
- preserves emotionalTone and themes from canonical metadata
- normalizes legacy/check-in tone sources safely
- suppresses returns for weak metadata
- suppresses returns during high-intensity current states
- adds recent-return spacing restraint
- adds scoped resurfacing guardrails

Validation:
- return restraint guards passed
- Khepera guards passed
- TypeScript passed
- production build passed
- scoped diff check passed

No Khepera generation, crisis detection, memory persistence, submission flow, AI orchestration, embeddings, or resurfacing modes added.