### PR TITLE
fix(app): stabilize splash startup

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "ALCHM",
   "short_name": "ALCHM",
-  "description": "A private space for quiet reflection and writing.",
+  "description": "A calm space for private writing.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#A8B5A0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -208,6 +208,67 @@
 }
 
 /* ─────────────────────────────────────────────────────────────────────
+   Launch Splash
+   ───────────────────────────────────────────────────────────────────── */
+.launch-splash {
+  position: relative;
+  display: grid;
+  min-height: 100vh;
+  min-height: 100dvh;
+  place-items: center;
+  overflow: hidden;
+  padding:
+    calc(env(safe-area-inset-top, 0px) + var(--space-8))
+    var(--page-padding-x)
+    calc(env(safe-area-inset-bottom, 0px) + var(--space-8));
+  background: var(--color-bg-app);
+  color: rgba(252, 247, 235, 0.92);
+  font-family: var(--font-family-body);
+}
+
+.launch-splash::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 42%, rgba(255, 255, 255, 0.08), transparent 34%),
+    linear-gradient(180deg, rgba(168, 181, 160, 0.96), rgba(139, 154, 124, 0.72));
+  pointer-events: none;
+}
+
+.launch-splash__center {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  justify-items: center;
+  transform: translateY(-5.5vh);
+}
+
+.launch-splash__wordmark {
+  margin: 0;
+  color: rgba(252, 247, 235, 0.94);
+  font-family: var(--font-family-heading);
+  font-size: clamp(54px, 16vw, 70px);
+  font-style: normal;
+  font-weight: var(--font-weight-regular);
+  letter-spacing: 0.01em;
+  line-height: 1;
+  text-align: center;
+  text-transform: none;
+}
+
+.launch-splash__subtitle {
+  margin: clamp(56px, 9vh, 84px) 0 0;
+  max-width: 280px;
+  color: rgba(252, 247, 235, 0.86);
+  font-family: var(--font-family-body);
+  font-size: 18px;
+  font-weight: var(--font-weight-regular);
+  line-height: 1.45;
+  text-align: center;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
    Containers Catalog
    ───────────────────────────────────────────────────────────────────── */
 .containers-loading,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,60 +3,56 @@
 import { useEffect, useRef } from 'react';
 import { useSafeNavigation } from '@/hooks/useSafeNavigation';
 import { isFirstTimeUser } from '@/lib/onboarding';
-import { DESIGN } from '@/lib/design';
+
+const STARTUP_DECISION_DELAY_MS = 900;
+const STARTUP_HARD_TIMEOUT_MS = 2400;
+
+function normalizePath(path: string): string {
+  return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+}
+
+function resolveStartupDestination(): string {
+  try {
+    return isFirstTimeUser() ? '/onboarding/' : '/dashboard/';
+  } catch {
+    return '/onboarding/';
+  }
+}
 
 export default function SplashPage() {
-  const { navigate } = useSafeNavigation(1200);
+  const { navigate } = useSafeNavigation(900);
   const hasStartedNavigation = useRef(false);
 
   useEffect(() => {
     if (hasStartedNavigation.current) return;
     hasStartedNavigation.current = true;
 
-    const timer = window.setTimeout(() => {
-      const destination = isFirstTimeUser() ? '/onboarding/' : '/dashboard/';
-      navigate(destination, { source: 'splash-auto', replace: true });
-    }, 650);
+    const destination = resolveStartupDestination();
+    const normalizedDestination = normalizePath(destination);
+
+    const navigationTimer = window.setTimeout(() => {
+      navigate(destination, { source: 'splash-auto', replace: true, fallbackMs: 900 });
+    }, STARTUP_DECISION_DELAY_MS);
+
+    const hardTimeout = window.setTimeout(() => {
+      const currentPath = normalizePath(window.location.pathname || '/');
+      if (currentPath === '/' || currentPath !== normalizedDestination) {
+        window.location.replace(normalizedDestination);
+      }
+    }, STARTUP_HARD_TIMEOUT_MS);
 
     return () => {
-      window.clearTimeout(timer);
+      window.clearTimeout(navigationTimer);
+      window.clearTimeout(hardTimeout);
     };
   }, [navigate]);
 
   return (
-    <div
-      className="min-h-screen flex flex-col items-center justify-center px-8 relative"
-      style={{
-        background: 'var(--color-bg-app)',
-        color: DESIGN.colors.textPrimary,
-        fontFamily: DESIGN.typography.sansSerif,
-        paddingTop: 'env(safe-area-inset-top, 0px)',
-        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
-      }}
-    >
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(255,255,255,0.15)_0%,_transparent_50%)]" />
-
-      <div className="relative flex flex-col items-center" aria-live="polite">
-        <h1
-          className="text-[52px] font-light"
-          style={{
-            color: 'rgba(255, 255, 255, 0.92)',
-            fontFamily: DESIGN.typography.serif,
-            letterSpacing: 0,
-            lineHeight: 1,
-            margin: 0,
-          }}
-        >
-          ALCHM
-        </h1>
-
-        <p
-          className="mt-8 text-center text-[18px] font-light leading-relaxed max-w-[280px]"
-          style={{ color: 'rgba(255, 255, 255, 0.84)' }}
-        >
-          Protecting your writing…
-        </p>
+    <main className="launch-splash" aria-label="ALCHM is opening">
+      <div className="launch-splash__center" aria-live="polite">
+        <h1 className="launch-splash__wordmark">ALCHM</h1>
+        <p className="launch-splash__subtitle">Protecting your writing…</p>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/components/CrisisFooter.tsx
+++ b/src/components/CrisisFooter.tsx
@@ -6,7 +6,7 @@ import { DESIGN } from '@/lib/design';
 const HIDDEN_FOOTER_PATHS = new Set(['/', '/onboarding']);
 
 function shouldHideFooter(pathname: string | null): boolean {
-  if (!pathname) return false;
+  if (!pathname) return true;
   const normalized = pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
   return HIDDEN_FOOTER_PATHS.has(normalized);
 }

--- a/src/components/ui/FooterNav.tsx
+++ b/src/components/ui/FooterNav.tsx
@@ -20,7 +20,7 @@ function isActive(pathname: string | null, href: string): boolean {
 }
 
 function shouldHideNav(pathname: string | null): boolean {
-  if (!pathname) return false;
+  if (!pathname) return true;
   const normalized = pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
   return HIDDEN_NAV_PATHS.has(normalized);
 }


### PR DESCRIPTION
Stabilizes the passive ALCHM splash and startup flow.

Includes:
- canonical passive splash with “Protecting your writing…”
- launch-specific CSS for wordmark/subtitle spacing
- bounded startup decision with hard fallback
- FooterNav/CrisisFooter hidden while pathname is unresolved and on splash/onboarding
- stale manifest launch description removed

Validation:
- npm run design:validate
- npm run qa:governance
- npm run lint
- npx tsc --noEmit
- npm run build
- repeated npm run build
- npm run e2e:navigation
- npx cap sync ios
- plutil -lint ios/App/App/PrivacyInfo.xcprivacy
- pod install
- xcodebuild clean build

No Khepera, crisis, memory, offline queue, Firebase, subscription, dependency, or governance changes.
