### PR TITLE
fix(containers): certify runtime route and handoff state

### DIFF
--- a/scripts/check-container-handoff-guards.js
+++ b/scripts/check-container-handoff-guards.js
@@ -19,6 +19,12 @@ const journalFlowSource = read('src/components/journal/JournalFlow.tsx');
 const containerDefinitionsSource = read('src/config/containerDefinitions.ts');
 const containerCatalogCardSource = read('src/components/containers/ContainerCatalogCard.tsx');
 const containerPageSource = read('src/app/containers/page.tsx');
+const containerDetailPageSource = read('src/app/containers/[id]/page.tsx');
+const containerTodayPageSource = read('src/app/containers/[id]/today/page.tsx');
+const containerThresholdPageSource = read('src/app/containers/[id]/threshold/page.tsx');
+const containerOpeningPageSource = read('src/app/containers/[id]/opening/page.tsx');
+const containerRitualPageSource = read('src/app/containers/[id]/ritual/page.tsx');
+const containerCeremonyPageSource = read('src/app/containers/[id]/ceremony/page.tsx');
 const containerTodaySource = read('src/app/containers/[id]/today/DailyThresholdClient.tsx');
 const containerThresholdSource = read('src/app/containers/[id]/threshold/DailyThresholdClient.tsx');
 const containerOpeningSource = read('src/app/containers/[id]/opening/OpeningRitualClient.tsx');
@@ -74,6 +80,7 @@ function assertNoContainerPressureLanguage(label, source) {
   ['container definitions', containerDefinitionsSource],
   ['container catalog card', containerCatalogCardSource],
   ['containers page', containerPageSource],
+  ['container detail page', containerDetailPageSource],
   ['container today screen', containerTodaySource],
   ['container threshold screen', containerThresholdSource],
   ['container opening screen', containerOpeningSource],
@@ -81,6 +88,17 @@ function assertNoContainerPressureLanguage(label, source) {
   ['container ceremony screen', containerCeremonySource],
   ['legacy container ceremony component', legacyCompletionCeremonySource],
 ].forEach(([label, source]) => assertNoContainerPressureLanguage(label, source));
+
+[
+  ['container detail route', containerDetailPageSource],
+  ['container opening route', containerOpeningPageSource],
+  ['container today route', containerTodayPageSource],
+  ['container threshold route', containerThresholdPageSource],
+  ['container ceremony route', containerCeremonyPageSource],
+  ['container ritual route', containerRitualPageSource],
+].forEach(([label, source]) => {
+  assert(source.includes('generateStaticParams'), `${label} must be statically generated for export`);
+});
 
 assert(
   todayClientSource.includes("onClick={() => router.push(`/journal/new?container=${containerId}&day=${currentDay}`)}"),
@@ -117,6 +135,14 @@ assert(
 assert(
   journalFlowSource.includes('containerContext: containerContext ?? undefined'),
   'JournalFlow must pass canonical ContainerContext into submission'
+);
+assert(
+  journalFlowSource.includes('recordEntry(result.entryId)'),
+  'JournalFlow must record completed non-crisis container entries after successful submission'
+);
+assert(
+  containerPageSource.includes('getUserContainersForUser(user.uid)'),
+  'containers page must load containers through the canonical container service with the current user id'
 );
 
 console.log('Container handoff regression guards passed.');

--- a/src/app/containers/[id]/ceremony/page.tsx
+++ b/src/app/containers/[id]/ceremony/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react';
+import { CONTAINER_DEFINITIONS } from '@/config/containerDefinitions';
+import { CompletionCeremonyClient } from './CompletionCeremonyClient';
+
+export function generateStaticParams(): Array<{ id: string }> {
+  return CONTAINER_DEFINITIONS.map(container => ({ id: container.id }));
+}
+
+export default function CeremonyPage() {
+  return (
+    <Suspense fallback={null}>
+      <CompletionCeremonyClient />
+    </Suspense>
+  );
+}

--- a/src/app/containers/[id]/opening/page.tsx
+++ b/src/app/containers/[id]/opening/page.tsx
@@ -1,0 +1,10 @@
+import { CONTAINER_DEFINITIONS } from '@/config/containerDefinitions';
+import OpeningRitualClient from './OpeningRitualClient';
+
+export function generateStaticParams(): Array<{ id: string }> {
+  return CONTAINER_DEFINITIONS.map(container => ({ id: container.id }));
+}
+
+export default function OpeningPage() {
+  return <OpeningRitualClient />;
+}

--- a/src/app/containers/[id]/page.tsx
+++ b/src/app/containers/[id]/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { CONTAINER_DEFINITIONS, getContainerDefinition } from '@/config/containerDefinitions';
+
+export function generateStaticParams(): Array<{ id: string }> {
+  return CONTAINER_DEFINITIONS.map(container => ({ id: container.id }));
+}
+
+export default function ContainerDetailPage({ params }: { params: { id: string } }) {
+  const container = getContainerDefinition(params.id);
+
+  if (!container) {
+    notFound();
+  }
+
+  return (
+    <main
+      className="container-detail-page"
+      data-container-atmosphere={container.atmosphere}
+    >
+      <Link className="btn-ghost container-detail-back" href="/containers">
+        Back to containers
+      </Link>
+
+      <section className="container-detail-card">
+        <p className="container-card__category">
+          {container.category}
+        </p>
+        <h1 className="container-card__title">
+          {container.name}
+        </h1>
+        <p className="container-card__tagline">
+          {container.tagline}
+        </p>
+        <p className="container-detail-copy">
+          {container.description}
+        </p>
+        <Link className="btn-primary container-detail-action" href={`/containers/${container.id}/opening`}>
+          Enter the container
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/containers/[id]/ritual/page.tsx
+++ b/src/app/containers/[id]/ritual/page.tsx
@@ -1,0 +1,10 @@
+import { CONTAINER_DEFINITIONS } from '@/config/containerDefinitions';
+import { OpeningRitualClient } from './OpeningRitualClient';
+
+export function generateStaticParams(): Array<{ id: string }> {
+  return CONTAINER_DEFINITIONS.map(container => ({ id: container.id }));
+}
+
+export default function RitualPage() {
+  return <OpeningRitualClient />;
+}

--- a/src/app/containers/[id]/threshold/page.tsx
+++ b/src/app/containers/[id]/threshold/page.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react';
+import { CONTAINER_DEFINITIONS } from '@/config/containerDefinitions';
+import { DailyThresholdClient } from './DailyThresholdClient';
+
+export function generateStaticParams(): Array<{ id: string }> {
+  return CONTAINER_DEFINITIONS.map(container => ({ id: container.id }));
+}
+
+export default function ThresholdPage() {
+  return (
+    <Suspense fallback={null}>
+      <DailyThresholdClient />
+    </Suspense>
+  );
+}

--- a/src/app/containers/[id]/today/page.tsx
+++ b/src/app/containers/[id]/today/page.tsx
@@ -1,0 +1,10 @@
+import { CONTAINER_DEFINITIONS } from '@/config/containerDefinitions';
+import DailyThresholdClient from './DailyThresholdClient';
+
+export function generateStaticParams(): Array<{ id: string }> {
+  return CONTAINER_DEFINITIONS.map(container => ({ id: container.id }));
+}
+
+export default function TodayPage() {
+  return <DailyThresholdClient />;
+}

--- a/src/app/containers/page.tsx
+++ b/src/app/containers/page.tsx
@@ -12,9 +12,9 @@ import { SectionIntro } from '@/components/ui/SectionIntro';
 import { ContainerCatalogCard } from '@/components/containers/ContainerCatalogCard';
 import { CONTAINER_DEFINITIONS } from '@/config/containerDefinitions';
 import { useAuth } from '@/hooks/useAuth';
-import { useData } from '@/hooks/useData';
 import { useSubscription } from '@/hooks/useSubscription';
 import { useInternalNavigation } from '@/hooks/useInternalNavigation';
+import { getUserContainersForUser } from '@/services/containers/containerService';
 import type { UserContainer } from '@/types/container';
 
 // ALCHM_IDENTITY_ROLE: supporting-screen
@@ -25,7 +25,6 @@ export default function ContainersPage() {
   const pathname = usePathname();
   const { user } = useAuth();
   const subscription = useSubscription();
-  const { getUserContainers } = useData();
   const [userContainers, setUserContainers] = useState<UserContainer[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -38,7 +37,7 @@ export default function ContainersPage() {
       }
 
       try {
-        const containers = await getUserContainers();
+        const containers = await getUserContainersForUser(user.uid);
         setUserContainers(containers);
       } catch (error) {
         console.error('Error loading user containers:', error);
@@ -48,7 +47,7 @@ export default function ContainersPage() {
     };
 
     loadContainers();
-  }, [user, getUserContainers]);
+  }, [user]);
 
   // Process container states
   type ActiveContainer = {
@@ -76,7 +75,7 @@ export default function ContainersPage() {
           containerId: activeContainer.containerId,
           userContainerId: activeContainer.id,
           hasWrittenToday: activeContainer.lastEntryAt
-            ? new Date(activeContainer.lastEntryAt.toDate()).toDateString() === new Date().toDateString()
+            ? toSafeDate(activeContainer.lastEntryAt).toDateString() === new Date().toDateString()
             : false,
         };
       }
@@ -200,7 +199,7 @@ export default function ContainersPage() {
                 const container = CONTAINER_DEFINITIONS.find(c => c.id === item.containerId);
                 return (
                   <AppText key={`${item.containerId}-${item.completedAt}`} variant="body">
-                    {container?.name || item.containerId} · {new Date((item.completedAt || item.startedAt).toDate()).toLocaleDateString()}
+                    {container?.name || item.containerId} · {toSafeDate(item.completedAt || item.startedAt).toLocaleDateString()}
                   </AppText>
                 );
               })}
@@ -220,4 +219,28 @@ export default function ContainersPage() {
       </div>
     </AppLayout>
   );
+}
+
+function toSafeDate(value: unknown): Date {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (
+    value &&
+    typeof value === 'object' &&
+    'toDate' in value &&
+    typeof (value as { toDate: () => Date }).toDate === 'function'
+  ) {
+    return (value as { toDate: () => Date }).toDate();
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return new Date();
 }

--- a/src/app/journal/new/page.tsx
+++ b/src/app/journal/new/page.tsx
@@ -6,6 +6,7 @@ import { JournalFlow } from '@/components/journal/JournalFlow';
 import { SanctuaryLayout } from '@/components/ui/SanctuaryLayout';
 import { SanctuaryHeader } from '@/components/ui/SanctuaryHeader';
 import { LoadingState } from '@/components/ui/LoadingState';
+import { getContainerDay, getContainerDefinition } from '@/config/containerDefinitions';
 import { getPathwayById } from '@/lib/pathways';
 
 export default function NewEntryPage() {
@@ -25,11 +26,30 @@ export default function NewEntryPage() {
 function NewEntryContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const containerId = searchParams?.get('container') || '';
+  const dayParam = searchParams?.get('day');
   const pathwayId = searchParams.get('pathway') || '';
   const pathwayStepIndex = Number.parseInt(searchParams.get('step') || '0', 10) || 0;
+  const containerDay = Number.parseInt(dayParam || '0', 10) || 0;
 
   const pathway = useMemo(() => (pathwayId ? getPathwayById(pathwayId) : null), [pathwayId]);
   const pathwayStep = pathway?.steps?.[pathwayStepIndex];
+  const containerOriginContext = useMemo(() => {
+    if (!containerId || !containerDay) return null;
+
+    const container = getContainerDefinition(containerId);
+    const day = getContainerDay(containerId, containerDay);
+    if (!container || !day) return null;
+
+    return {
+      containerId: container.id,
+      name: container.name,
+      dayLabel: `Day ${containerDay} of ${container.totalDays}`,
+      prompt: day.prompt,
+      somaticAnchor: day.somaticAnchor,
+      phaseLabel: day.phase,
+    };
+  }, [containerDay, containerId]);
 
   const quickStartContext = pathwayStep
     ? {
@@ -43,6 +63,9 @@ function NewEntryContent() {
     <SanctuaryLayout header={<SanctuaryHeader title="New Entry" showBack />} noPadding>
       <JournalFlow
         quickStartContext={quickStartContext}
+        containerPrompt={containerOriginContext?.prompt}
+        somaticAnchor={containerOriginContext?.somaticAnchor}
+        containerOriginContext={containerOriginContext}
         thresholdQuestion={pathwayStep?.prompt}
         completionContext={{
           destination: 'journal',

--- a/src/components/journal/JournalFlow.tsx
+++ b/src/components/journal/JournalFlow.tsx
@@ -37,7 +37,7 @@ export function JournalFlow({
   const { navigate } = useInternalNavigation();
   const auth = useAuth();
   const userId = auth.user?.uid;
-  const { activeContainer, containerContext } = useContainer();
+  const { activeContainer, containerContext, recordEntry } = useContainer();
   const { view, entryText, result, error, setEntryText, submit, reset } = useJournal();
   useSafeAsync();
   const prefersReducedMotion = useReducedMotionPreference();
@@ -51,6 +51,7 @@ export function JournalFlow({
     () => getStorageItemWithFallback(STORAGE_KEYS.FIRST_ENTRY_COMPLETED) !== 'true'
   );
   const hasRecordedStart = useRef(false);
+  const recordedContainerEntryIdRef = useRef<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   void completionContext;
@@ -125,6 +126,23 @@ export function JournalFlow({
     setShowKheperaCard(false);
     setReceivingInteractive(false);
   }, [phase, result, isFirstEntryExperience, prefersReducedMotion]);
+
+  useEffect(() => {
+    if (
+      !result?.entryId ||
+      result.isCrisis ||
+      result.submissionState !== 'completed' ||
+      !containerOriginContext ||
+      recordedContainerEntryIdRef.current === result.entryId
+    ) {
+      return;
+    }
+
+    recordedContainerEntryIdRef.current = result.entryId;
+    void recordEntry(result.entryId).catch(() => {
+      // The entry is already saved; container state can be recovered on the next visit.
+    });
+  }, [containerOriginContext, recordEntry, result]);
 
   const promptContext = containerPrompt ?? containerContext?.todayPrompt ?? quickStartContext?.prompt;
   const writingPrompt = promptContext

--- a/src/services/containers/containerService.ts
+++ b/src/services/containers/containerService.ts
@@ -1,4 +1,4 @@
-import { collection, doc, getDoc, getDocs, limit, query, setDoc, updateDoc, serverTimestamp, Timestamp, where } from 'firebase/firestore';
+import { collection, doc, getDoc, getDocs, limit, orderBy, query, setDoc, updateDoc, serverTimestamp, Timestamp, where } from 'firebase/firestore';
 import { getFirestoreDb } from '@/services/firebase/firebaseService';
 import { getContainerDefinition } from '@/config/containerDefinitions';
 import { getContainerPhase, CONTAINER_PHASES } from '@/config/containerArc';
@@ -60,7 +60,7 @@ export async function getActiveContainerState(
   if (!definition) return null;
 
   // Advance day if needed (new calendar day since last entry)
-  const advancedDay = computeCurrentDay(uc);
+  const advancedDay = computeCurrentDay(uc, definition.totalDays);
   if (advancedDay !== uc.currentDay) {
     await advanceDay(userId, userContainerId, uc.currentDay, advancedDay);
     uc.currentDay = advancedDay;
@@ -73,7 +73,7 @@ export async function getActiveContainerState(
   const phaseConfig = phase ? CONTAINER_PHASES[phase.lunarPhase as keyof typeof CONTAINER_PHASES] : CONTAINER_PHASES.grounding;
 
   const hasWrittenToday = uc.lastEntryAt
-    ? isToday(uc.lastEntryAt.toDate())
+    ? isToday(toDate(uc.lastEntryAt))
     : false;
 
   return {
@@ -104,6 +104,20 @@ export async function getActiveContainerStateForUser(userId: string): Promise<Ac
   if (!activeContainerId) return null;
 
   return getActiveContainerState(userId, activeContainerId);
+}
+
+export async function getUserContainersForUser(userId: string): Promise<UserContainer[]> {
+  const db = getFirestoreDb();
+  const containersQuery = query(
+    collection(db, 'users', userId, 'containers'),
+    orderBy('startedAt', 'desc')
+  );
+  const containersSnapshot = await getDocs(containersQuery);
+
+  return containersSnapshot.docs.map(containerDoc => ({
+    id: containerDoc.id,
+    ...containerDoc.data(),
+  }) as UserContainer);
 }
 
 export function buildContainerContext(state: ActiveContainerState): ContainerContext {
@@ -154,12 +168,11 @@ export async function completeContainer(
 }
 
 // Private helpers
-function computeCurrentDay(uc: UserContainer): number {
+function computeCurrentDay(uc: UserContainer, totalDays: number): number {
   if (!uc.lastEntryAt) return uc.currentDay;
-  if (isToday(uc.lastEntryAt.toDate())) return uc.currentDay;
+  if (isToday(toDate(uc.lastEntryAt))) return uc.currentDay;
 
   // New calendar day — advance by 1 (never more)
-  const totalDays = 21; // Default to 21, should get from definition
   const next = Math.min(uc.currentDay + 1, totalDays);
   return next;
 }
@@ -179,4 +192,28 @@ function isToday(date: Date): boolean {
   return date.getFullYear() === now.getFullYear()
     && date.getMonth() === now.getMonth()
     && date.getDate() === now.getDate();
+}
+
+function toDate(value: unknown): Date {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (
+    value &&
+    typeof value === 'object' &&
+    'toDate' in value &&
+    typeof (value as { toDate: () => Date }).toDate === 'function'
+  ) {
+    return (value as { toDate: () => Date }).toDate();
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return new Date();
 }


### PR DESCRIPTION
Certifies Containers runtime route and handoff state.

Includes:
- adds App Router wrappers for container dynamic routes
- loads user container state through canonical containerService with current Firebase user id
- normalizes container date handling
- records container entries only after successful completed non-crisis submissions
- prevents duplicate recordEntry calls
- bounds current day by actual container definition length
- extends container handoff guards

Validation:
- node scripts/check-container-handoff-guards.js
- node scripts/check-container-today-polish-guards.js
- npm run design:validate
- npm run qa:governance
- npm run qa:khepera-guards
- npm run lint
- npx tsc --noEmit
- npm run build
- repeated npm run build
- npm run e2e:navigation
- npx cap sync ios
- plutil -lint ios/App/App/PrivacyInfo.xcprivacy
- pod install
- xcodebuild clean build

No Khepera, crisis, memory, offline queue/replay, Firebase/Firestore schema, subscription, dependency, or governance philosophy changes.
